### PR TITLE
Postpone extra ESA functions

### DIFF
--- a/local.bib
+++ b/local.bib
@@ -24,20 +24,3 @@ archivePrefix = "arXiv",
        adsurl = {https://ui.adsabs.harvard.edu/abs/1997ESASP1200.....E},
       adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
-
-@ARTICLE{2000A&AS..143....9W,
-       author = {{Wenger}, M. and {Ochsenbein}, F. and {Egret}, D. and {Dubois}, P. and {Bonnarel}, F. and {Borde}, S. and {Genova}, F. and {Jasniewicz}, G. and {Lalo{\"e}}, S. and {Lesteven}, S. and {Monier}, R.},
-        title = "{The SIMBAD astronomical database. The CDS reference database for astronomical objects}",
-      journal = {\aaps},
-     keywords = {ASTRONOMICAL DATA BASES: MISCELLANEOUS, CATALOGS, Astrophysics},
-         year = 2000,
-        month = apr,
-       volume = {143},
-        pages = {9-22},
-          doi = {10.1051/aas:2000332},
-archivePrefix = {arXiv},
-       eprint = {astro-ph/0002110},
- primaryClass = {astro-ph},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2000A&AS..143....9W},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}

--- a/local.bib
+++ b/local.bib
@@ -12,8 +12,8 @@ archivePrefix = "arXiv",
   adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
-@PROCEEDINGS{1997ESASP1200.....E,
-				author = "ESA",
+@MISC{1997ESASP1200.....E,
+				author = {{ESA}},
         title = "{The HIPPARCOS and TYCHO catalogues. Astrometric and photometric star catalogues derived from the ESA HIPPARCOS Space Astrometry Mission}",
      keywords = {SPACE ASTROMETRY, STAR CATALOGS, POSITIONS, ARTIFICIAL SATELLITES},
     booktitle = {ESA Special Publication},

--- a/udf-catalogue.tex
+++ b/udf-catalogue.tex
@@ -282,7 +282,7 @@ are passed as indices, but may choose to do some rounding.
 
 \subsection{Astrometry}
 
-\subsubsection{ivo\_epoch\_prop\_pos(ra, dec, parallax, pmra, pmdec,\\
+\subsubsection{ivo\_epoch\_prop\_pos(ra, dec, parallax, pmra, pmdec,
   radial\_velocity, ref\_epoch, out\_epoch)}
 \label{epoch_prop_pos}
 
@@ -387,6 +387,7 @@ ivo_epoch_prop_pos(7.606083572, 11.79044105, 125,
 \end{examples}
 
 
+<<<<<<< HEAD
 \subsubsection{ivo\_transform(from\_sys, to\_sys, geo)}
 
 Transforms ADQL geometries (i.e., at least values of type \verb|POINT|,
@@ -442,19 +443,39 @@ from \verb|from_sys| to \verb|to_sys|.
 \item[Return type] The function returns a value of the same type as
 \verb|geo|
 
+\subsubsection{ivo\_epoch\_prop(ra, dec, parallax, pmra, pmdec,
+  radial\_velocity, ref\_epoch, out\_epoch)}
+
+This is epoch\_prop\_pos as described in Sect.~\ref{epoch_prop_pos},
+except it returns a full parameter set at out\_epoch.
+
+\begin{description}
+\item[Parameters]
+  As for epoch\_prop\_pos.
+
+\item[Return type] REAL[6], consisting of the longitude and latitude in
+degrees, the parallax in mas, the proper motion in longitude and
+latitude in mas/yr, and the radial velocity in km/s.  As in the input
+parameters, the proper motion in longitude is given for the tangential
+plane (``has ${\textrm cos}(\delta)$ applied'').
+
+
 \item[Source] This document, version 1.1
 \end{description}
 
-\subsection{Dates and Times}
-
-\subsubsection{ivo\_to\_jd(d TIMESTAMP)}
-
-\todo{Schreiben}
-
-\subsubsection{ivo\_to\_mjd(d TIMESTAMP)}
-
-\todo{Schreiben}
-
+\begin{examples}
+\example \begin{lstlisting}
+ivo_epoch_prop(7.606083572, 11.79044105, 125,
+  300, -428.8, 52.51, 2016.0, 1992.25)
+\end{lstlisting}
+\becomes [7.6040614046279735, 11.793270382827929, 125.01993165584682,\\
+300.09877325973605, -428.934593565712, 52.50880381775256]
+\example \begin{lstlisting}
+ivo_epoch_prop(7.606083572, 11.79044105, 125,
+  NULL, NULL, NULL, 2016.0, 1992.25)
+\end{lstlisting}
+\becomes [7.606083572000001, 11.79044105, 125.0, 0.0, 0.0, 0.0]
+\end{examples}
 
 \subsection{Text-Related}
 
@@ -688,10 +709,6 @@ FROM gaiadr3.nss_vim_fl
 \done on the TAP service at \url{http://dc.g-vo.org/tap}.
 \end{examples}
 
-\subsubsection{ivo\_normal\_random(mu REAL, sigma REAL)}
-
-\todo{Schreiben}
-
 \subsection{Convenience Functions}
 
 \subsubsection{ivo\_interval\_overlaps(a1, b1, a2, b2)}
@@ -742,10 +759,6 @@ bound $>$ upper bound never overlap with anything.
 lower bound is probably not a good idea for floating point numbers that
 do not have a short and finite binary representation.
 \end{examples}
-
-\subsubsection{ivo\_simbadpoint(identifier TEXT)}
-
-\todo{Schreiben}
 
 \appendix
 

--- a/udf-catalogue.tex
+++ b/udf-catalogue.tex
@@ -752,43 +752,9 @@ FROM gaiadr3.nss_vim_fl
 \done on the TAP service at \url{http://dc.g-vo.org/tap}.
 \end{examples}
 
-\subsubsection{ivo\_normal\_random(mu, sigma)}
+\subsubsection{ivo\_normal\_random(mu REAL, sigma REAL)}
 
-Returns a random number drawn from a normal distribution
-\begin{equation}
-\label{normaldist}
-\frac{1}{\sqrt{2\pi\sigma^2}}
-\exp\left(-\frac{(x-\mu)^2}{2\sigma^2}\right).
-\end{equation}
-
-Implementation note: Few databases at this point have built-in
-facilities for drawing random numbers from non-uniform distributions.
-In practice, an implementation of the type
-\begin{lstlisting}
-(((random()+random()+random()+random()+random()
-  +random()+random()+random()+random()+random()-5
-)*sigma)+mu)
-\end{lstlisting}
-has been giving sufficiently good results and adequate runtime
-behaviour.  Of course, better approximations are preferred.
-
-\begin{description}
-\item[Parameters]
-\begin{args}
-  \arg mu (REAL) -- the $\mu$ in eq.~(\ref{normaldist})
-  \arg sigma (REAL) -- the $\sigma$ in eq.~(\ref{normaldist})
-\end{args}
-
-\item[Return Type] REAL
-
-\item[Source] This document, version 1.1
-\end{description}
-
-\begin{examples}
-\example \verb|ivo_normal_random(10, 5), ivo_normal_random(10, 5)|
-\becomes 3.4275427, 7.839408
-\done (or, really, almost anything else).
-\end{examples}
+\todo{Schreiben}
 
 \subsection{Convenience Functions}
 

--- a/udf-catalogue.tex
+++ b/udf-catalogue.tex
@@ -442,46 +442,14 @@ from \verb|from_sys| to \verb|to_sys|.
 \item[Return type] The function returns a value of the same type as
 \verb|geo|
 
-\item[Source] This document, version 1.1\todo{Examples!}
+\item[Source] This document, version 1.1
 \end{description}
 
 \subsection{Dates and Times}
 
-\subsubsection{ivo\_to\_jd(d)}
+\subsubsection{ivo\_to\_jd(d TIMESTAMP)}
 
-Converts a database timestamp to a Julian Date as a floating point
-number. This is naive; no corrections for timezones, let alone time
-scales or the like are done. Users can thus not expect this to be good
-to second-precision unless they are careful in the construction of the
-timestamp.
-
-\begin{description}
-\item[Parameters]
-\begin{args}
-\arg d (TIMESTAMP literal) -- a SQL timestamp.
-\end{args}
-
-\item[Return type] \verb|REAL|
-
-\item[Source] This document, version 1.1
-\end{description}
-
-\begin{examples}
-\example \verb|ivo_to_jd(CAST('2000-01-02T12:00:00' AS TIMESTAMP))|
-\becomes \verb|2451546.0|
-\done.
-
-\example \verb|ivo_to_jd('1910-12-31T06:00:00')|
-\becomes \verb|2419036.75|
-\done While not strictly necessary for compliance, implementations
-SHOULD accept reasonable strings -- primarily, DALI-style ISO dates --
-as arguments, in particular when they do not implement the optional CAST
-construct.
-
-\example \verb|ivo_to_jd(NULL)|
-\becomes NULL
-\done.
-\end{examples}
+\todo{Schreiben}
 
 \subsubsection{ivo\_to\_mjd(d TIMESTAMP)}
 

--- a/udf-catalogue.tex
+++ b/udf-catalogue.tex
@@ -100,8 +100,9 @@ changes.  In effect, this endorsed note is the management tool for
 the \verb|ivo_| ``namespace'' in ADQL user defined functions.
 
 Note that no function given here is required to be present in a generic
-TAP service (though other standards may pose such requirements;
-\verb|ivo_hashlist_has|, for instance, is required by both
+TAP service (though other standards may pose such requirements; for
+instance,
+\verb|ivo_hashlist_has| is required by both
 RegTAP and EPN-TAP).  However, if a service implements any UDF with a
 name mentioned in this document, its semantics must be as specified here.
 
@@ -282,7 +283,7 @@ are passed as indices, but may choose to do some rounding.
 
 \subsection{Astrometry}
 
-\subsubsection{ivo\_epoch\_prop\_pos(ra, dec, parallax, pmra, pmdec,
+\subsubsection{ivo\_epoch\_prop\_pos(ra, dec, parallax, pmra, pmdec,\\
   radial\_velocity, ref\_epoch, out\_epoch)}
 \label{epoch_prop_pos}
 
@@ -307,8 +308,7 @@ compatibility with established UDFs at major TAP service providers.
 \item[Parameters]
 \begin{args}
 \arg ra (REAL) -- the object's longitude at \texttt{ref\_epoch}, in
-degrees.  NULL values here are an error\todo{Or should the whole thing
-return NULL instead?}.
+degrees.  NULL values here are an error.
 
 \arg dec (REAL) -- the object's latitude at \texttt{ref\_epoch}, in
 degrees.  NULL values here are an error.
@@ -384,97 +384,6 @@ ivo_epoch_prop_pos(7.606083572, 11.79044105, 125,
   300, -428.8, 52.51, NULL, 1875.0)
 \end{lstlisting}
 \becomes an error
-\end{examples}
-
-
-<<<<<<< HEAD
-\subsubsection{ivo\_transform(from\_sys, to\_sys, geo)}
-
-Transforms ADQL geometries (i.e., at least values of type \verb|POINT|,
-\verb|CIRCLE|, or verb|POLYGON|) between various reference systems. The
-function will return a geometry of the same type as the \verb|geo|
-argument.
-
-As specified here, \verb|from_sys| and \verb|to_sys| must be literal
-strings (i.e., they cannot be computed through expressions or be taken
-from database columns), although implementors are free to accept more
-general string expressions as an extension.  The identifiers of the
-reference frames must be taken from the IVOA refframe
-vocabulary\footnote{\url{http://www.ivoa.net/rdf/refframe}}, where
-additional reference frames can be added as needed as described in
-\citet{2023ivoa.spec.0206D}.  Services publishing sky data are advised
-to implement ICRS and GALACTIC at the very least.
-
-Implementations should list the reference frames supported in their
-local descriptions of this function.
-
-Reference frame identifiers are case-sensitive.
-
-For reproducability, all transforms should be implemented as simple
-rotations. This is only a rough approximation to the actual
-relationships between reference systems, and applications requiring high
-levels of precision in references frame transforms have to perform these
-outside of the database.
-
-For equinox-dependent frames, we for now define default equinoxes:
-
-\begin{itemize}
-\item FK5: J2000.0
-\item FK4: J1950.0
-\item ECLIPTIC: J2000.0
-\end{itemize}
-
-A later version of this document may define a four-argument form of
-ivo\_transform which allows the specification of equinoxes or other
-frame-dependent metadata.
-
-\begin{description}
-\item[Parameters]
-\begin{args}
-\arg from\_sys (string literal) -- the refframe identifier of the system
-\verb|geo| is in.
-\arg to\_sys (string literal) -- the refframe identifier of the system
-the return value is in.
-\arg geo (GEOMETRY) -- a \verb|POINT|, \verb|CIRCLE|, or \verb|POLYGON|
-(accepting and transforming additional types is permitted)  to transform
-from \verb|from_sys| to \verb|to_sys|.
-\end{args}
-
-\item[Return type] The function returns a value of the same type as
-\verb|geo|
-
-\subsubsection{ivo\_epoch\_prop(ra, dec, parallax, pmra, pmdec,
-  radial\_velocity, ref\_epoch, out\_epoch)}
-
-This is epoch\_prop\_pos as described in Sect.~\ref{epoch_prop_pos},
-except it returns a full parameter set at out\_epoch.
-
-\begin{description}
-\item[Parameters]
-  As for epoch\_prop\_pos.
-
-\item[Return type] REAL[6], consisting of the longitude and latitude in
-degrees, the parallax in mas, the proper motion in longitude and
-latitude in mas/yr, and the radial velocity in km/s.  As in the input
-parameters, the proper motion in longitude is given for the tangential
-plane (``has ${\textrm cos}(\delta)$ applied'').
-
-
-\item[Source] This document, version 1.1
-\end{description}
-
-\begin{examples}
-\example \begin{lstlisting}
-ivo_epoch_prop(7.606083572, 11.79044105, 125,
-  300, -428.8, 52.51, 2016.0, 1992.25)
-\end{lstlisting}
-\becomes [7.6040614046279735, 11.793270382827929, 125.01993165584682,\\
-300.09877325973605, -428.934593565712, 52.50880381775256]
-\example \begin{lstlisting}
-ivo_epoch_prop(7.606083572, 11.79044105, 125,
-  NULL, NULL, NULL, 2016.0, 1992.25)
-\end{lstlisting}
-\becomes [7.606083572000001, 11.79044105, 125.0, 0.0, 0.0, 0.0]
 \end{examples}
 
 \subsection{Text-Related}

--- a/udf-catalogue.tex
+++ b/udf-catalogue.tex
@@ -29,7 +29,6 @@
 \input{exampledef}
 \fi
 
-\newcommand{\aaps}{Astronomy and Astrophysics Supplement}
 
 \title{Catalogue of ADQL User Defined Functions}
 
@@ -842,38 +841,9 @@ lower bound is probably not a good idea for floating point numbers that
 do not have a short and finite binary representation.
 \end{examples}
 
-\subsubsection{ivo\_simbadpoint(identifier)}
+\subsubsection{ivo\_simbadpoint(identifier TEXT)}
 
-Queries Simbad \citep{2000A&AS..143....9W} for a position of
-\verb|identifier| and returns
-a POINT for that position.  This is mainly a convenience function, as
-\verb|identifier| must be a literal (as opposed to a column reference or
-expression).  For mass resolution of identifiers, Simbad's own TAP
-service should be used.
-
-\begin{description}
-\item[Parameters]
-\begin{args}
-	\arg identifier (string literal) -- A Simbad-resolvable identifier.
-\end{args}
-
-\item[Return type] \texttt{POINT}
-
-\item[Source] This document, version 1.1
-\end{description}
-
-\begin{examples}
-\example \verb|ivo_simbadpoint('GJ 699')|
-\becomes \verb|POINT(269.452076958619, 4.69336496657667)|)
-\done (where Simbad returns estimated current positions and hence
-return values will change over time -- significantly so for the present
-example, Barnard's star).
-
-\example \verb|ivo_simbadpoint('an invalid identifier')|
-\becomes an error
-\done The error message should ideally state that the identifier passed
-in (which ought to be included in the message) cannot be resolved by Simbad.
-\end{examples}
+\todo{Schreiben}
 
 \appendix
 
@@ -916,12 +886,8 @@ scheme alternative to HEALPix.
 \subsection{Changes from EN-1.0}
 
 \begin{itemize}
-\item Added \verb|ivo_histogram|, \verb|ivo_normal_random| as statistics
-functions (gavo, ari, esa)
-\item Added \verb|ivo_epoch_prop_pos|, and
-\verb|ivo_transform| as astrometry functions (gavo, esa)
-\item Added \verb|ivo_to_jd|, \verb|ivo_to_mjd| as date functions (gavo, esa)
-\item Added \verb|ivo_simbadpoint| as convenience function (gavo, esa)
+\item Added \verb|ivo_epoch_prop_pos| (gavo, esa)
+\item Added \verb|ivo_histogram| (gavo, ari)
 \end{itemize}
 
 \subsection{Changes from PEN-20200806}

--- a/udf-catalogue.tex
+++ b/udf-catalogue.tex
@@ -452,7 +452,7 @@ from \verb|from_sys| to \verb|to_sys|.
 Converts a database timestamp to a Julian Date as a floating point
 number. This is naive; no corrections for timezones, let alone time
 scales or the like are done. Users can thus not expect this to be good
-to second-level precision unless they are careful in the construction of the
+to second-precision unless they are careful in the construction of the
 timestamp.
 
 \begin{description}
@@ -485,39 +485,7 @@ construct.
 
 \subsubsection{ivo\_to\_mjd(d TIMESTAMP)}
 
-Converts a database timestamp to a Modified Julian Date as a floating
-point number. This is naive; no corrections for timezones, let alone
-time scales or the like are done. Users can thus not expect this to be
-good to second-level precision unless they are careful in the construction of
-the timestamp.
-
-\begin{description}
-\item[Parameters]
-\begin{args}
-\arg d (TIMESTAMP literal) -- a SQL timestamp.
-\end{args}
-
-\item[Return type] \verb|REAL|
-
-\item[Source] This document, version 1.1
-\end{description}
-
-\begin{examples}
-\example \verb|ivo_to_mjd(CAST('2000-01-02T12:00:00' AS TIMESTAMP))|
-\becomes \verb|51545.5|
-\done.
-
-\example \verb|ivo_to_mjd('1910-12-31T06:00:00')|
-\becomes \verb|19036.25|
-\done While not strictly necessary for compliance, implementations
-SHOULD accept reasonable strings -- primarily, DALI-style ISO dates --
-as arguments, in particular when they do not implement the optional CAST
-construct.
-
-\example \verb|ivo_to_mjd(NULL)|
-\becomes NULL
-\done.
-\end{examples}
+\todo{Schreiben}
 
 
 \subsection{Text-Related}


### PR DESCRIPTION
ESA needs a little extra time to publish the extra functions added in commits aba19f099ee1f5694d4c7bd71e847953e26c2612, bb32c32e89311fbe47ac2e3138fac69ac3d67382, 493873f2c352c4f81ab0d2f190b6e016a2524510, 05b949379c754a9fd0d70052f5f4ceb192f623ea, and 19c63ebac11839298edc5a68e4ce938c45927e90.  We revert these commits in order to have a TCG review on the other two functions ins 2023.  We will re-add this material some time in 2024.