### PR TITLE
Release for EN 1.0.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ DOCVERSION = 1.1
 DOCDATE = 2023-10-10
 
 # What is it you're writing: NOTE, WD, PR, REC, PEN, or EN
-DOCTYPE = PEN
+DOCTYPE = EN
 
 # An e-mail address of the person doing the submission to the document
 # repository (can be empty until a make upload is being made)
@@ -26,10 +26,10 @@ FIGURES = role_diagram.svg
 
 # List of PDF figures (figures that must be converted to pixel images to
 # work in web browsers).
-VECTORFIGURES = 
+VECTORFIGURES =
 
 # Additional files to distribute (e.g., CSS, schema files, examples...)
-AUX_FILES = 
+AUX_FILES =
 
 -include ivoatex/Makefile
 

--- a/udf-catalogue.tex
+++ b/udf-catalogue.tex
@@ -55,9 +55,7 @@ identical functionality is available under identical names in different
 services.  Therefore, ADQL 2.1 has introduced the \verb|ivo_| prefix,
 reserved for functions with agreed-upon semantics.  This endorsed note
 contains this agreement and, via its updates, is the means of updating
-it.  A non-normative appendix lists UDFs declared by registered TAP
-services; some of these might be developed into consensus UDFs in later
-releases.
+it.
 \end{abstract}
 
 
@@ -106,11 +104,6 @@ instance,
 \verb|ivo_hashlist_has| is required by both
 RegTAP and EPN-TAP).  However, if a service implements any UDF with a
 name mentioned in this document, its semantics must be as specified here.
-
-Informationally, in each revision of this document, we also run an
-all-VO survey of user defined functions in registered TAP services.  A
-digest of this survey is given in the non-normative
-Appendix~\ref{app:otherudfs}.
 
 \subsection{Role within the VO Architecture}
 


### PR DESCRIPTION
This is after endorsement at the TCG meeting in Tucson, https://wiki.ivoa.net/twiki/bin/view/IVOA/Meeting_2023-11-10

Editorial change: some references to the appendix with the VO-wide UDF survey were inadvertently left in commit c3e5f0b7.