### PR TITLE
Removing link to preview PDF.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-[![PDF-Preview](https://img.shields.io/badge/Preview-PDF-blue)](../../releases/download/auto-pdf-preview/udf-catalogue-draft.pdf)
-
 ## ADQL User Defined Functions catalogue
 
 IVOA endorsed note on ADQL User Defined Functions.  Stable versions of


### PR DESCRIPTION
For one, it's using stuff from shields.io, and then we've not enabled CI for the UDF cat.  Since folks should review what's in the doc repo, I'd say we don't need to, either.