### PR TITLE
Re-add GAVO/ESAC batch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,13 +4,13 @@
 DOCNAME = udf-catalogue
 
 # count up; you probably do not want to bother with versions <1.0
-DOCVERSION = 1.1
+DOCVERSION = 1.2
 
 # Publication date, ISO format; update manually for "releases"
-DOCDATE = 2023-10-10
+DOCDATE = 2023-11-22
 
 # What is it you're writing: NOTE, WD, PR, REC, PEN, or EN
-DOCTYPE = EN
+DOCTYPE = PEN
 
 # An e-mail address of the person doing the submission to the document
 # repository (can be empty until a make upload is being made)

--- a/local.bib
+++ b/local.bib
@@ -24,3 +24,20 @@ archivePrefix = "arXiv",
        adsurl = {https://ui.adsabs.harvard.edu/abs/1997ESASP1200.....E},
       adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
+
+@ARTICLE{2000A&AS..143....9W,
+       author = {{Wenger}, M. and {Ochsenbein}, F. and {Egret}, D. and {Dubois}, P. and {Bonnarel}, F. and {Borde}, S. and {Genova}, F. and {Jasniewicz}, G. and {Lalo{\"e}}, S. and {Lesteven}, S. and {Monier}, R.},
+        title = "{The SIMBAD astronomical database. The CDS reference database for astronomical objects}",
+      journal = {\aaps},
+     keywords = {ASTRONOMICAL DATA BASES: MISCELLANEOUS, CATALOGS, Astrophysics},
+         year = 2000,
+        month = apr,
+       volume = {143},
+        pages = {9-22},
+          doi = {10.1051/aas:2000332},
+archivePrefix = {arXiv},
+       eprint = {astro-ph/0002110},
+ primaryClass = {astro-ph},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2000A&AS..143....9W},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}

--- a/udf-catalogue.tex
+++ b/udf-catalogue.tex
@@ -337,17 +337,49 @@ position.  NULL values here are an error.
 
 \begin{examples}
 \example \begin{lstlisting}
-<<<<<<< HEAD
-ivo_epoch_prop(7.606083572, 11.79044105, 125,
+ivo_epoch_prop_pos(7.606083572, 11.79044105, 125,
   300, -428.8, 52.51, 2016.0, 1992.25)
 \end{lstlisting}
-\becomes [7.6040614046279735, 11.793270382827929, 125.01993165584682,\\
-300.09877325973605, -428.934593565712, 52.50880381775256]
+\becomes [7.604061404627978, 11.7932703828279]\done
+where [] denote an array and we use DALI representation.
+
 \example \begin{lstlisting}
-ivo_epoch_prop(7.606083572, 11.79044105, 125,
-  NULL, NULL, NULL, 2016.0, 1992.25)
+ivo_epoch_prop_pos(7.606083572, 11.79044105, 125,
+  300, -428.8, 52.51, 2016.0, 1875.0)
 \end{lstlisting}
-\becomes [7.606083572000001, 11.79044105, 125.0, 0.0, 0.0, 0.0]
+\becomes [7.594068213694308, 11.807251375203935]\done.
+
+\example \begin{lstlisting}
+ivo_epoch_prop_pos(7.606083572, 11.79044105, 125,
+  300, -428.8, NULL, 2016.0, 1875.0)
+\end{lstlisting}
+\becomes [7.594079587029898, 11.807235464326332]\done.
+
+\example \begin{lstlisting}
+ivo_epoch_prop_pos(7.606083572, 11.79044105, 125,
+  300, NULL, NULL, 2016.0, 1875.0)
+\end{lstlisting}
+\becomes [7.594080321498365, 11.790440798509207]\done.
+
+\begin{lstlisting}
+ivo_epoch_prop_pos(7.606083572, 11.79044105, NULL,
+  300, -428.8, 52.51, 2016.0, 1875.0)
+\end{lstlisting}
+\becomes [7.594079587020846, 11.807235464339055] \done This last value
+is approximative in the sense that the concrete ``small'' parallax has
+not been fixed normatively.
+
+\example \begin{lstlisting}
+ivo_epoch_prop_pos(NULL, 11.79044105, 125,
+  300, NULL, NULL, 2016.0, 1875.0)
+\end{lstlisting}
+\becomes an error.
+
+\example \begin{lstlisting}
+ivo_epoch_prop_pos(7.606083572, 11.79044105, 125,
+  300, -428.8, 52.51, NULL, 1875.0)
+\end{lstlisting}
+\becomes an error.
 \end{examples}
 
 
@@ -385,10 +417,10 @@ ivo_epoch_prop(7.606083572, 11.79044105, 125,
 \becomes [7.606083572000001, 11.79044105, 125.0, 0.0, 0.0, 0.0]
 \end{examples}
 
-\subsubsection{ivo\_transform(from\_sys, to\_sys, geo)}
+\subsubsection{ivo\_geom\_transform(from\_sys, to\_sys, geo)}
 
 Transforms ADQL geometries (i.e., at least values of type \verb|POINT|,
-\verb|CIRCLE|, or verb|POLYGON|) between various reference systems. The
+\verb|CIRCLE|, or \verb|POLYGON|) between various reference systems. The
 function will return a geometry of the same type as the \verb|geo|
 argument.
 
@@ -422,8 +454,8 @@ For equinox-dependent frames, we for now define default equinoxes:
 \end{itemize}
 
 A later version of this document may define a four-argument form of
-ivo\_transform which allows the specification of equinoxes or other
-frame-dependent metadata.
+ivo\_transform to support passing equinoxes or other metadata
+influencing the transformation.
 
 \begin{description}
 \item[Parameters]
@@ -440,9 +472,23 @@ from \verb|from_sys| to \verb|to_sys|.
 \item[Return type] The function returns a value of the same type as
 \verb|geo|
 
-\item[Source] This document, version 1.1\todo{Examples!}
+\item[Source] This document, version 1.2
 \end{description}
 
+\begin{examples}
+\example \verb|ivo_geom_transform('ICRS', 'GALACTIC', POINT(120, -23))|
+\becomes \verb|[241.121831182, 3.62785788087]|\done
+in limited-precision DALI representation, where [] denote an array.
+
+\example \verb|ivo_geom_transform('FK4', 'GALACTIC', CIRCLE(189.70303055, 22.96240006, 3))|
+\becomes \verb|[275.00025405, 84.99996154, 3]|.
+
+\example \verb|ivo_geom_transform('FK4', 'GALACTIC', CIRCLE(189.70303055, 22.96240006, 3))|
+\becomes \verb|[275.00025405, 84.99996154, 3]|.
+
+\example \verb|ivo_geom_transform('GALACTIC', 'FK5', POLYGON(5, 3, 4, 4, 4.5, 2))|
+\becomes \verb|[266.44721, -23.107310, 264.95088, -23.434037, 267.09936, -24.051919]|.
+\end{examples}
 
 \subsection{Dates and Times}
 
@@ -462,8 +508,25 @@ timestamp.
 
 \item[Return type] \verb|REAL|
 
-\item[Source] This document, version 1.2\todo{Examples!}
+\item[Source] This document, version 1.2
 \end{description}
+
+\begin{examples}
+\example \verb|ivo_to_jd(CAST('2000-01-02T12:00:00' AS TIMESTAMP))|
+\becomes \verb|2451546.0|
+\done.
+
+\example \verb|ivo_to_jd('1910-12-31T06:00:00')|
+\becomes \verb|2419036.75|
+\done While not strictly necessary for compliance, implementations
+SHOULD accept reasonable strings -- primarily, DALI-style ISO dates --
+as arguments, in particular when they do not implement the optional CAST
+construct.
+
+\example \verb|ivo_to_jd(NULL)|
+\becomes NULL
+\done.
+\end{examples}
 
 \subsubsection{ivo\_to\_mjd(d)}
 
@@ -734,7 +797,6 @@ FROM gaiadr3.nss_vim_fl
 \done on the TAP service at \url{http://dc.g-vo.org/tap}.
 \end{examples}
 
-<<<<<<< HEAD
 \subsubsection{ivo\_normal\_random(mu, sigma)}
 
 Returns a random number drawn from a normal distribution
@@ -846,7 +908,7 @@ service should be used.
 
 \begin{examples}
 \example \verb|ivo_simbadpoint('GJ 699')|
-\becomes \verb|POINT(269.452076958619, 4.69336496657667)|)
+\becomes \verb|[269.452076958619, 4.69336496657667]|
 \done (where Simbad returns estimated current positions and hence
 return values will change over time -- significantly so for the present
 example, Barnard's star).
@@ -864,7 +926,8 @@ in (which ought to be included in the message) cannot be resolved by Simbad.
 \subsection{Changes from EN-1.1}
 
 \begin{itemize}
-\item Added \verb|ivo_epoch_prop| as astrometry function (gavo, esa)
+\item Added \verb|ivo_epoch_prop| and \verb|ivo_geom_transform|
+as astrometry function (gavo, esa)
 \item Added \verb|ivo_simbadpoint| as convenience function (gavo, esa)
 \item Added \verb|ivo_normal_random| as a statstics function (gavo, esa)
 \item Added \verb|ivo_to_jd| and \verb|ivo_to_mjd| as a datetime

--- a/udf-catalogue.tex
+++ b/udf-catalogue.tex
@@ -42,6 +42,7 @@
 
 \editor[https://wiki.ivoa.net/twiki/bin/view/IVOA/JonJuaristiCampillo]{Jon Juaristi Campillo}
 
+\previousversion[https://www.ivoa.net/documents/udf-catalogue/20231010]{EN-1.1}
 \previousversion[https://www.ivoa.net/documents/udf-catalogue/20210310]{EN-1.0}
 \previousversion[https://ivoa.net/documents/udf-catalogue/20200806/]{PEN-20200806}
 \previousversion[https://ivoa.net/documents/udf-catalogue/20190925]{PEN-20190925}

--- a/udf-catalogue.tex
+++ b/udf-catalogue.tex
@@ -337,6 +337,7 @@ position.  NULL values here are an error.
 
 \begin{examples}
 \example \begin{lstlisting}
+<<<<<<< HEAD
 ivo_epoch_prop(7.606083572, 11.79044105, 125,
   300, -428.8, 52.51, 2016.0, 1992.25)
 \end{lstlisting}
@@ -349,53 +350,8 @@ ivo_epoch_prop(7.606083572, 11.79044105, 125,
 \becomes [7.606083572000001, 11.79044105, 125.0, 0.0, 0.0, 0.0]
 \end{examples}
 
-\begin{examples}
-\example \begin{lstlisting}
-ivo_epoch_prop_pos(7.606083572, 11.79044105, 125,
-  300, -428.8, 52.51, 2016.0, 1992.25)
-\end{lstlisting}
-\becomes [7.604061404627978, 11.7932703828279]\done.
 
-\example \begin{lstlisting}
-ivo_epoch_prop_pos(7.606083572, 11.79044105, 125,
-  300, -428.8, 52.51, 2016.0, 1875.0)
-\end{lstlisting}
-\becomes [7.594068213694308, 11.807251375203935]\done.
-
-\example \begin{lstlisting}
-ivo_epoch_prop_pos(7.606083572, 11.79044105, 125,
-  300, -428.8, NULL, 2016.0, 1875.0)
-\end{lstlisting}
-\becomes [7.594079587029898, 11.807235464326332]\done.
-
-\example \begin{lstlisting}
-ivo_epoch_prop_pos(7.606083572, 11.79044105, 125,
-  300, NULL, NULL, 2016.0, 1875.0)
-\end{lstlisting}
-\becomes [7.594080321498365, 11.790440798509207]\done.
-
-\begin{lstlisting}
-ivo_epoch_prop_pos(7.606083572, 11.79044105, NULL,
-  300, -428.8, 52.51, 2016.0, 1875.0)
-\end{lstlisting}
-\becomes [7.594079587020846, 11.807235464339055] \done This last value
-is approximative in the sense that the concrete ``small'' parallax has
-not been fixed normatively.
-
-\example \begin{lstlisting}
-ivo_epoch_prop_pos(NULL, 11.79044105, 125,
-  300, NULL, NULL, 2016.0, 1875.0)
-\end{lstlisting}
-\becomes an error\done.
-
-\example \begin{lstlisting}
-ivo_epoch_prop_pos(7.606083572, 11.79044105, 125,
-  300, -428.8, 52.51, NULL, 1875.0)
-\end{lstlisting}
-\becomes an error\done.
-\end{examples}
-
-\subsubsection{ivo\_epoch\_prop(ra, dec, parallax, pmra, pmdec,\\
+\subsubsection{ivo\_epoch\_prop(ra, dec, parallax, pmra, pmdec,
   radial\_velocity, ref\_epoch, out\_epoch)}
 
 This is epoch\_prop\_pos as described in Sect.~\ref{epoch_prop_pos},
@@ -411,8 +367,82 @@ latitude in mas/yr, and the radial velocity in km/s.  As in the input
 parameters, the proper motion in longitude is given for the tangential
 plane (``has ${\textrm cos}(\delta)$ applied'').
 
-\item[Source] This document, version 1.2
+
+\item[Source] This document, version 1.1
 \end{description}
+
+\begin{examples}
+\example \begin{lstlisting}
+ivo_epoch_prop(7.606083572, 11.79044105, 125,
+  300, -428.8, 52.51, 2016.0, 1992.25)
+\end{lstlisting}
+\becomes [7.6040614046279735, 11.793270382827929, 125.01993165584682,\\
+300.09877325973605, -428.934593565712, 52.50880381775256]
+\example \begin{lstlisting}
+ivo_epoch_prop(7.606083572, 11.79044105, 125,
+  NULL, NULL, NULL, 2016.0, 1992.25)
+\end{lstlisting}
+\becomes [7.606083572000001, 11.79044105, 125.0, 0.0, 0.0, 0.0]
+\end{examples}
+
+\subsubsection{ivo\_transform(from\_sys, to\_sys, geo)}
+
+Transforms ADQL geometries (i.e., at least values of type \verb|POINT|,
+\verb|CIRCLE|, or verb|POLYGON|) between various reference systems. The
+function will return a geometry of the same type as the \verb|geo|
+argument.
+
+As specified here, \verb|from_sys| and \verb|to_sys| must be literal
+strings (i.e., they cannot be computed through expressions or be taken
+from database columns), although implementors are free to accept more
+general string expressions as an extension.  The identifiers of the
+reference frames must be taken from the IVOA refframe
+vocabulary\footnote{\url{http://www.ivoa.net/rdf/refframe}}, where
+additional reference frames can be added as needed as described in
+\citet{2023ivoa.spec.0206D}.  Services publishing sky data are advised
+to implement ICRS and GALACTIC at the very least.
+
+Implementations should list the reference frames supported in their
+local descriptions of this function.
+
+Reference frame identifiers are case-sensitive.
+
+For reproducability, all transforms should be implemented as simple
+rotations. This is only a rough approximation to the actual
+relationships between reference systems, and applications requiring high
+levels of precision in references frame transforms have to perform these
+outside of the database.
+
+For equinox-dependent frames, we for now define default equinoxes:
+
+\begin{itemize}
+\item FK5: J2000.0
+\item FK4: J1950.0
+\item ECLIPTIC: J2000.0
+\end{itemize}
+
+A later version of this document may define a four-argument form of
+ivo\_transform which allows the specification of equinoxes or other
+frame-dependent metadata.
+
+\begin{description}
+\item[Parameters]
+\begin{args}
+\arg from\_sys (string literal) -- the refframe identifier of the system
+\verb|geo| is in.
+\arg to\_sys (string literal) -- the refframe identifier of the system
+the return value is in.
+\arg geo (GEOMETRY) -- a \verb|POINT|, \verb|CIRCLE|, or \verb|POLYGON|
+(accepting and transforming additional types is permitted)  to transform
+from \verb|from_sys| to \verb|to_sys|.
+\end{args}
+
+\item[Return type] The function returns a value of the same type as
+\verb|geo|
+
+\item[Source] This document, version 1.1\todo{Examples!}
+\end{description}
+
 
 \subsection{Dates and Times}
 
@@ -435,7 +465,7 @@ timestamp.
 \item[Source] This document, version 1.2\todo{Examples!}
 \end{description}
 
-\subsubsection{ivo\_to\_mjd(d TIMESTAMP)}
+\subsubsection{ivo\_to\_mjd(d)}
 
 Converts a database timestamp to a Modified Julian Date as a floating
 point number. This is naive; no corrections for timezones, let alone
@@ -704,6 +734,7 @@ FROM gaiadr3.nss_vim_fl
 \done on the TAP service at \url{http://dc.g-vo.org/tap}.
 \end{examples}
 
+<<<<<<< HEAD
 \subsubsection{ivo\_normal\_random(mu, sigma)}
 
 Returns a random number drawn from a normal distribution

--- a/udf-catalogue.tex
+++ b/udf-catalogue.tex
@@ -380,6 +380,39 @@ ivo_epoch_prop_pos(7.606083572, 11.79044105, 125,
 \becomes an error\done.
 \end{examples}
 
+\subsubsection{ivo\_epoch\_prop(ra, dec, parallax, pmra, pmdec,\\
+  radial\_velocity, ref\_epoch, out\_epoch)}
+
+This is epoch\_prop\_pos as described in Sect.~\ref{epoch_prop_pos},
+except it returns a full parameter set at out\_epoch.
+
+\begin{description}
+\item[Parameters]
+  As for epoch\_prop\_pos.
+
+\item[Return type] REAL[6], consisting of the longitude and latitude in
+degrees, the parallax in mas, the proper motion in longitude and
+latitude in mas/yr, and the radial velocity in km/s.  As in the input
+parameters, the proper motion in longitude is given for the tangential
+plane (``has ${\textrm cos}(\delta)$ applied'').
+
+\item[Source] This document, version 1.1
+\end{description}
+
+\begin{examples}
+\example \begin{lstlisting}
+ivo_epoch_prop(7.606083572, 11.79044105, 125,
+  300, -428.8, 52.51, 2016.0, 1992.25)
+\end{lstlisting}
+\becomes [7.6040614046279735, 11.793270382827929, 125.01993165584682,\\
+300.09877325973605, -428.934593565712, 52.50880381775256]
+\example \begin{lstlisting}
+ivo_epoch_prop(7.606083572, 11.79044105, 125,
+  NULL, NULL, NULL, 2016.0, 1992.25)
+\end{lstlisting}
+\becomes [7.606083572000001, 11.79044105, 125.0, 0.0, 0.0, 0.0]
+\end{examples}
+
 \subsection{Text-Related}
 
 \subsubsection{ivo\_string\_agg(expression, delimiter)}
@@ -666,6 +699,12 @@ do not have a short and finite binary representation.
 \appendix
 
 \section{Changes from Previous Versions}
+
+\subsection{Changes from EN-1.1}
+
+\begin{itemize}
+\item Adding \verb|ivo_epoch_prop| as astrometry function (gavo, esa)
+\end{itemize}
 
 \subsection{Changes from EN-1.0}
 

--- a/udf-catalogue.tex
+++ b/udf-catalogue.tex
@@ -29,6 +29,7 @@
 \input{exampledef}
 \fi
 
+\newcommand{\aaps}{Astronomy and Astrophysics Supplement}
 
 \title{Catalogue of ADQL User Defined Functions}
 
@@ -696,6 +697,39 @@ lower bound is probably not a good idea for floating point numbers that
 do not have a short and finite binary representation.
 \end{examples}
 
+\subsubsection{ivo\_simbadpoint(identifier)}
+
+Queries Simbad \citep{2000A&AS..143....9W} for a position of
+\verb|identifier| and returns
+a POINT for that position.  This is mainly a convenience function, as
+\verb|identifier| must be a literal (as opposed to a column reference or
+expression).  For mass resolution of identifiers, Simbad's own TAP
+service should be used.
+
+\begin{description}
+\item[Parameters]
+\begin{args}
+	\arg identifier (string literal) -- A Simbad-resolvable identifier.
+\end{args}
+
+\item[Return type] \texttt{POINT}
+
+\item[Source] This document, version 1.1
+\end{description}
+
+\begin{examples}
+\example \verb|ivo_simbadpoint('GJ 699')|
+\becomes \verb|POINT(269.452076958619, 4.69336496657667)|)
+\done (where Simbad returns estimated current positions and hence
+return values will change over time -- significantly so for the present
+example, Barnard's star).
+
+\example \verb|ivo_simbadpoint('an invalid identifier')|
+\becomes an error
+\done The error message should ideally state that the identifier passed
+in (which ought to be included in the message) cannot be resolved by Simbad.
+\end{examples}
+
 \appendix
 
 \section{Changes from Previous Versions}
@@ -704,6 +738,7 @@ do not have a short and finite binary representation.
 
 \begin{itemize}
 \item Adding \verb|ivo_epoch_prop| as astrometry function (gavo, esa)
+\item Added \verb|ivo_simbadpoint| as convenience function (gavo, esa)
 \end{itemize}
 
 \subsection{Changes from EN-1.0}

--- a/udf-catalogue.tex
+++ b/udf-catalogue.tex
@@ -337,6 +337,20 @@ position.  NULL values here are an error.
 
 \begin{examples}
 \example \begin{lstlisting}
+ivo_epoch_prop(7.606083572, 11.79044105, 125,
+  300, -428.8, 52.51, 2016.0, 1992.25)
+\end{lstlisting}
+\becomes [7.6040614046279735, 11.793270382827929, 125.01993165584682,\\
+300.09877325973605, -428.934593565712, 52.50880381775256]
+\example \begin{lstlisting}
+ivo_epoch_prop(7.606083572, 11.79044105, 125,
+  NULL, NULL, NULL, 2016.0, 1992.25)
+\end{lstlisting}
+\becomes [7.606083572000001, 11.79044105, 125.0, 0.0, 0.0, 0.0]
+\end{examples}
+
+\begin{examples}
+\example \begin{lstlisting}
 ivo_epoch_prop_pos(7.606083572, 11.79044105, 125,
   300, -428.8, 52.51, 2016.0, 1992.25)
 \end{lstlisting}
@@ -400,19 +414,63 @@ plane (``has ${\textrm cos}(\delta)$ applied'').
 \item[Source] This document, version 1.2
 \end{description}
 
+\subsection{Dates and Times}
+
+\subsubsection{ivo\_to\_jd(d)}
+
+Converts a database timestamp to a Julian Date as a floating point
+number. This is naive; no corrections for timezones, let alone time
+scales or the like are done. Users can thus not expect this to be good
+to second-precision unless they are careful in the construction of the
+timestamp.
+
+\begin{description}
+\item[Parameters]
+\begin{args}
+\arg d (TIMESTAMP literal) -- a SQL timestamp.
+\end{args}
+
+\item[Return type] \verb|REAL|
+
+\item[Source] This document, version 1.2\todo{Examples!}
+\end{description}
+
+\subsubsection{ivo\_to\_mjd(d TIMESTAMP)}
+
+Converts a database timestamp to a Modified Julian Date as a floating
+point number. This is naive; no corrections for timezones, let alone
+time scales or the like are done. Users can thus not expect this to be
+good to second-level precision unless they are careful in the construction of
+the timestamp.
+
+\begin{description}
+\item[Parameters]
+\begin{args}
+\arg d (TIMESTAMP literal) -- a SQL timestamp.
+\end{args}
+
+\item[Return type] \verb|REAL|
+
+\item[Source] This document, version 1.1
+\end{description}
+
 \begin{examples}
-\example \begin{lstlisting}
-ivo_epoch_prop(7.606083572, 11.79044105, 125,
-  300, -428.8, 52.51, 2016.0, 1992.25)
-\end{lstlisting}
-\becomes [7.6040614046279735, 11.793270382827929, 125.01993165584682,\\
-300.09877325973605, -428.934593565712, 52.50880381775256]
-\example \begin{lstlisting}
-ivo_epoch_prop(7.606083572, 11.79044105, 125,
-  NULL, NULL, NULL, 2016.0, 1992.25)
-\end{lstlisting}
-\becomes [7.606083572000001, 11.79044105, 125.0, 0.0, 0.0, 0.0]
+\example \verb|ivo_to_mjd(CAST('2000-01-02T12:00:00' AS TIMESTAMP))|
+\becomes \verb|51545.5|
+\done.
+
+\example \verb|ivo_to_mjd('1910-12-31T06:00:00')|
+\becomes \verb|19036.25|
+\done While not strictly necessary for compliance, implementations
+SHOULD accept reasonable strings -- primarily, DALI-style ISO dates --
+as arguments, in particular when they do not implement the optional CAST
+construct.
+
+\example \verb|ivo_to_mjd(NULL)|
+\becomes NULL
+\done.
 \end{examples}
+
 
 \subsection{Text-Related}
 
@@ -775,9 +833,11 @@ in (which ought to be included in the message) cannot be resolved by Simbad.
 \subsection{Changes from EN-1.1}
 
 \begin{itemize}
-\item Adding \verb|ivo_epoch_prop| as astrometry function (gavo, esa)
+\item Added \verb|ivo_epoch_prop| as astrometry function (gavo, esa)
 \item Added \verb|ivo_simbadpoint| as convenience function (gavo, esa)
 \item Added \verb|ivo_normal_random| as a statstics function (gavo, esa)
+\item Added \verb|ivo_to_jd| and \verb|ivo_to_mjd| as a datetime
+functions (gavo, esa)
 \end{itemize}
 
 \subsection{Changes from EN-1.0}

--- a/udf-catalogue.tex
+++ b/udf-catalogue.tex
@@ -397,7 +397,7 @@ latitude in mas/yr, and the radial velocity in km/s.  As in the input
 parameters, the proper motion in longitude is given for the tangential
 plane (``has ${\textrm cos}(\delta)$ applied'').
 
-\item[Source] This document, version 1.1
+\item[Source] This document, version 1.2
 \end{description}
 
 \begin{examples}
@@ -646,6 +646,44 @@ FROM gaiadr3.nss_vim_fl
 \done on the TAP service at \url{http://dc.g-vo.org/tap}.
 \end{examples}
 
+\subsubsection{ivo\_normal\_random(mu, sigma)}
+
+Returns a random number drawn from a normal distribution
+\begin{equation}
+\label{normaldist}
+\frac{1}{\sqrt{2\pi\sigma^2}}
+\exp\left(-\frac{(x-\mu)^2}{2\sigma^2}\right).
+\end{equation}
+
+Implementation note: Few databases at this point have built-in
+facilities for drawing random numbers from non-uniform distributions.
+In practice, an implementation of the type
+\begin{lstlisting}
+(((random()+random()+random()+random()+random()
+  +random()+random()+random()+random()+random()-5
+)*sigma)+mu)
+\end{lstlisting}
+has been giving sufficiently good results and adequate runtime
+behaviour.  Of course, better approximations are preferred.
+
+\begin{description}
+\item[Parameters]
+\begin{args}
+  \arg mu (REAL) -- the $\mu$ in eq.~(\ref{normaldist})
+  \arg sigma (REAL) -- the $\sigma$ in eq.~(\ref{normaldist})
+\end{args}
+
+\item[Return Type] REAL
+
+\item[Source] This document, version 1.2
+\end{description}
+
+\begin{examples}
+\example \verb|ivo_normal_random(10, 5), ivo_normal_random(10, 5)|
+\becomes 3.4275427, 7.839408
+\done (or, really, almost anything else).
+\end{examples}
+
 \subsection{Convenience Functions}
 
 \subsubsection{ivo\_interval\_overlaps(a1, b1, a2, b2)}
@@ -714,7 +752,7 @@ service should be used.
 
 \item[Return type] \texttt{POINT}
 
-\item[Source] This document, version 1.1
+\item[Source] This document, version 1.2
 \end{description}
 
 \begin{examples}
@@ -739,6 +777,7 @@ in (which ought to be included in the message) cannot be resolved by Simbad.
 \begin{itemize}
 \item Adding \verb|ivo_epoch_prop| as astrometry function (gavo, esa)
 \item Added \verb|ivo_simbadpoint| as convenience function (gavo, esa)
+\item Added \verb|ivo_normal_random| as a statstics function (gavo, esa)
 \end{itemize}
 
 \subsection{Changes from EN-1.0}


### PR DESCRIPTION
This PR adds back the new common GAVO/ESA functions.

That's ivo_epoch_prop, ivo_geom_transform, ivo_simbadpoint,
ivo_normal_random, ivo_to_jd, ivo_to_mjd.  Against the original commits,
we have renamed ivo_geom_transform and added a few examples for it.