### PR TITLE
Fix  upquotes in \verb

### DIFF
--- a/udf-catalogue.tex
+++ b/udf-catalogue.tex
@@ -8,6 +8,9 @@
 \usepackage{xifthen}
 \lstloadlanguages{XML,SQL}
 \lstset{flexiblecolumns=true,basicstyle=\ttfamily,belowskip=0pt}
+% we want cut-and-pasteable upquotes in \verb here (for listings,
+% this is done in ivoatex)
+\usepackage{upquote}
 
 \iftth
 \newenvironment{args}%


### PR DESCRIPTION
This is because we have a lot of listings-like material in \verb here, and
we want this to be cut-and-pasteable into queries so people can properly
test things.  I *think* this should go into ivoatex, but let's see what
the impact is here first.