### PR TITLE
Correct PEN 1.2 w/ fixed references

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,14 +7,14 @@ DOCNAME = udf-catalogue
 DOCVERSION = 1.2
 
 # Publication date, ISO format; update manually for "releases"
-DOCDATE = 2024-02-02
+DOCDATE = 2024-08-07
 
 # What is it you're writing: NOTE, WD, PR, REC, PEN, or EN
 DOCTYPE = PEN
 
 # An e-mail address of the person doing the submission to the document
 # repository (can be empty until a make upload is being made)
-AUTHOR_EMAIL=msdemlei@ari.uni-heidelberg.de
+AUTHOR_EMAIL=juaristi@uni-heidelberg.de
 
 # Source files for the TeX document (but the main file must always
 # be called $(DOCNAME).tex

--- a/udf-catalogue.tex
+++ b/udf-catalogue.tex
@@ -79,7 +79,7 @@ infrastructure that enable VO applications.
 
 \section{Introduction}
 
-The Astronomical Data Query Language (ADQL) \citep{2008ivoa.spec.1030O}
+The Astronomical Data Query Language (ADQL) \citep{2023ivoa.spec.1215M}
 has the notion of user defined functions (UDF).  These provide a
 light-weight extension mechanism for operators of TAP services.
 For instance, \citet{2016arXiv161109190T} show how they enable the
@@ -123,7 +123,7 @@ IVOA architecture \citep{2021ivoa.spec.1101D}.  It relates to the following
 other standards:
 
 \begin{bigdescription}
-\item[ADQL \citep{2008ivoa.spec.1030O}] This endorsed note defines the
+\item[ADQL \citep{2023ivoa.spec.1215M}] This endorsed note defines the
 user defined functions with the \verb|ivo_| prefix.  While ADQL 2.0
 does not treat those as special, they can be (and have been) used there
 already.  Normative language on \verb|ivo_| is expected to become
@@ -135,7 +135,7 @@ refer to this note rather than maintaining a second definition, and
 deferring the actual definition of UDFs to this note should be the
 standard way of introducing UDFs used or required by a standard in the future.
 
-\item[MOC \citep{2019ivoa.spec.1007F}] The HEALPix functions defined
+\item[MOC \citep{2022ivoa.spec.0727F}] The HEALPix functions defined
 here build on terminology introduced in the MOC specification.
 \end{bigdescription}
 
@@ -171,7 +171,7 @@ functions.
 
 In this section, order and npix are used as in the Multi-Order
 Coverage map (MOC) recommendation
-\citep{2019ivoa.spec.1007F}.
+\citep{2022ivoa.spec.0727F}.
 
 \subsubsection{ivo\_healpix\_index(hpxOrder, long, lat)}
 


### PR DESCRIPTION
A version of the 1.2 PEN was uploaded earlier this year, but epoch_prop_pos has been removed in the meanwhile -- the new document will be uploaded after merging.

A couple of outdated references have been also fixed.