### PR TITLE
Add link to PDF preview

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
         sudo apt install texlive-latex-base texlive-latex-recommended texlive-latex-extra texlive-fonts-recommended xsltproc latexmk cm-super
       
     - name: Build the document
-      run: make
+      run: make biblio forcetex
       
     - name: Check the output
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
         sudo apt install texlive-latex-base texlive-latex-recommended texlive-latex-extra texlive-fonts-recommended xsltproc latexmk cm-super
       
     - name: Build the document
-      run: make biblio forcetex
+      run: make gitmeta.tex biblio forcetex
       
     - name: Check the output
       run: |

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -27,7 +27,7 @@ jobs:
         sudo snap install pdftk
     
     - name: Build the document
-      run: make biblio ${{ env.doc_name }}-draft.pdf
+      run: make gitmeta.tex biblio ${{ env.doc_name }}-draft.pdf
     
     - name: Check the output
       run: |

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -27,7 +27,7 @@ jobs:
         sudo snap install pdftk
     
     - name: Build the document
-      run: make ${{ env.doc_name }}-draft.pdf
+      run: make biblio ${{ env.doc_name }}-draft.pdf
     
     - name: Check the output
       run: |
@@ -35,10 +35,10 @@ jobs:
         test -f ${{ env.doc_name }}.bbl
     
     - name: Move the auto-pdf-preview tag
-      uses: weareyipyip/walking-tag-action@v1
+      uses: weareyipyip/walking-tag-action@v2
       with:
-        TAG_NAME: auto-pdf-preview
-        TAG_MESSAGE: |
+        tag-name: auto-pdf-preview
+        tag-message: |
           Last commit taken into account for the automatically updated PDF preview of this IVOA document.
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![PDF-Preview](https://img.shields.io/badge/Preview-PDF-blue)](../../releases/download/auto-pdf-preview/udf-catalogue-draft.pdf)
+
 ## ADQL User Defined Functions catalogue
 
 This is the source code for the list of interoperable user defined functions


### PR DESCRIPTION
This Pull Request should:

1. Add a link (as a badge) in the README toward the PDF preview of the last committed version in the `master` branch.
2. Fix the `preview` workflow configuration.

_Anyway, actions are now enabled in this repository. For some reason, it was not._